### PR TITLE
Add Drag & Drop and Context Menu Functionality to Playlists

### DIFF
--- a/Background Changer/WallpaperManager.swift
+++ b/Background Changer/WallpaperManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 
 enum WallpaperError: Error {
     case invalidScreen
@@ -473,6 +474,21 @@ class WallpaperManager: ObservableObject {
             return nil
         }
         return (wallpaperURL, image)
+    }
+    
+    func moveWallpaper(from sourcePlaylist: Playlist, at sourceIndex: Int, to targetPlaylist: Playlist, at targetIndex: Int) {
+        guard let sourcePlaylistIndex = playlists.firstIndex(where: { $0.id == sourcePlaylist.id }),
+              let targetPlaylistIndex = playlists.firstIndex(where: { $0.id == targetPlaylist.id }) else {
+            return
+        }
+        
+        withAnimation {
+            let wallpaper = playlists[sourcePlaylistIndex].wallpapers.remove(at: sourceIndex)
+            playlists[targetPlaylistIndex].wallpapers.insert(wallpaper, at: targetIndex)
+            
+            try? savePlaylists()
+            updateLoadedPlaylists()
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds two major features to improve playlist management:

### Drag & Drop Functionality
- Added ability to reorder wallpapers within playlists
- Visual indicator shows where items will be placed during drag
- Smooth animations during reordering
- Support for dragging between different playlists

### Context Menu
- Added right-click context menu for wallpapers
- Menu options include:
  - Set as Wallpaper
  - Show in Finder
  - Remove from Playlist
- Immediate access to common actions

### Technical Changes
- Added UniformTypeIdentifiers for drag & drop support
- Implemented PlaylistDropDelegate for handling drag operations
- Added state management for drag operations
- Integrated SwiftUI animations for smooth transitions
- Added moveWallpaper method to WallpaperManager

### Testing
- Tested drag & drop within same playlist
- Tested drag & drop between different playlists
- Verified context menu functionality
- Confirmed proper state updates after operations

### Screenshots
[You can add screenshots here if desired]